### PR TITLE
feat: Added publishing of compressed images in Tello driver.

### DIFF
--- a/tello_driver/launch/tello_driver.launch.py
+++ b/tello_driver/launch/tello_driver.launch.py
@@ -30,9 +30,23 @@ def generate_launch_description():
         output="screen",
     )
 
+    compressed_image_node = Node(
+        package="image_transport",
+        namespace=LaunchConfiguration("ns"),
+        executable="republish",
+        arguments=["raw", "compressed"],
+        parameters=[LaunchConfiguration("params_file")],
+        remappings=[
+            ("in", "/camera/image_raw"),
+            ("out/compressed", "/camera/image/compressed"),
+        ],
+    )
+
     ld = LaunchDescription()
     ld.add_action(params_file_arg)
     ld.add_action(ns_launch_arg)
     ld.add_action(tello_driver_node)
+    ld.add_action(compressed_image_node)
+
 
     return ld


### PR DESCRIPTION
Used image_transport to republish raw images as compressed on a new topic.
All modifications were done in the tello driver's launch file.
The tello_driver now depends on [image_transport](https://github.com/ros-perception/image_common)