### PR TITLE
fix: Updated compressed image topic name.

### DIFF
--- a/tello_driver/launch/tello_driver.launch.py
+++ b/tello_driver/launch/tello_driver.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         parameters=[LaunchConfiguration("params_file")],
         remappings=[
             ("in", "/camera/image_raw"),
-            ("out/compressed", "/camera/image/compressed"),
+            ("out/compressed", "/camera/image_raw/compressed"),
         ],
     )
 


### PR DESCRIPTION
Changed the name of the topic for compressed images to /camera/image_raw/compressed for consistency with /camera/image_raw. 
The only file mofidied is the launch file of the tello driver package.